### PR TITLE
Add service worker and fix registration path

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,7 +63,7 @@ function mostrarConfirmacion() {
 
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('/service-worker.js')
+      navigator.serviceWorker.register('service-worker.js')
         .then(reg => console.log("✅ Service Worker registrado:", reg.scope))
         .catch(err => console.error("❌ Error al registrar Service Worker:", err));
     });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'nails-v1';
+const FILES_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js',
+  '/logo1-removebg-preview.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- register service worker using relative path
- add a basic service worker for offline caching

## Testing
- `node --check script.js`
- `node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_6863125111f8832985cc15621bcf3c75